### PR TITLE
changed to work with new pin api

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,8 +104,8 @@ function reduceBuffer(buf, start, end, fn, res) {
 exports.use = function (port, cb) {
     var card = new events.EventEmitter(),
         spi = null,         // re-initialized to various settings until card is ready
-        csn = port.digital[1],
-        ppn = port.digital[2];      // "physically present (negated)"
+        csn = port.digital[0],
+        ppn = port.digital[1];      // "physically present (negated)"
     
     csn.output();
     ppn.input();


### PR DESCRIPTION
Just a heads up, when https://github.com/tessel/firmware/pull/122 lands it'll change the tessel.port.digital pins from being 1 indexed to 0 indexed.
