### PR TITLE
workaround for failing WRITE_MILTIPLE_BLOCK calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,9 @@ When true (the default), the library will wait for a card to be physically inser
 &#x20;<a href="#api-watchCard" name="api-watchCard">#</a> <b>watchCard</b>  
 If set to true, your script will never finish but the instance will emit the 'inserted' and 'removed' events as documented above. Defaults to false.  
 
+&#x20;<a href="#api-safeWrites" name="api-safeWrites">#</a> <b>safeWrites</b>  
+Some cards fail on `WRITE_MULTIPLE_BLOCK`, if set to true multiple `WRITE_BLOCK` calls are used instead. This is slower and false by default.
+
 ###Further Examples
 See the examples folder for code.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ When true (the default), the library will wait for a card to be physically inser
 &#x20;<a href="#api-watchCard" name="api-watchCard">#</a> <b>watchCard</b>  
 If set to true, your script will never finish but the instance will emit the 'inserted' and 'removed' events as documented above. Defaults to false.  
 
-&#x20;<a href="#api-safeWrites" name="api-safeWrites">#</a> <b>safeWrites</b>  
+&#x20;<a href="#api-singleWrites" name="api-singleWrites">#</a> <b>singleWrites</b>  
 Some cards fail on `WRITE_MULTIPLE_BLOCK`, if set to true multiple `WRITE_BLOCK` calls are used instead. This is slower and false by default.
 
 ###Further Examples

--- a/index.js
+++ b/index.js
@@ -137,7 +137,8 @@ exports.use = function (port, opts, callback) {
   opts = extend({
     getFilesystems: false,
     waitForCard: true,
-    watchCard: false
+    watchCard: false,
+    safeWrites: false
   }, opts);
   
   var card = new events.EventEmitter(),
@@ -685,7 +686,15 @@ exports.use = function (port, opts, callback) {
     }, true);
   }, _nested); }
   
-  function writeBlocks(i, data, callback, _nested) {
+  function writeBlocks(i, data, callback, _nested){
+    if (!opts.safeWrites) {
+       writeBlocksMulti(i, data, callback, _nested);
+    } else {
+       writeBlocksSafe(i, data, callback, _nested);
+    }
+  };
+
+  function writeBlocksMulti(i, data, callback, _nested) {
     callback = SPI_TRANSACTION_WRAPPER(callback, function () {
       if (data.length % BLOCK_SIZE) {
         throw Error("Must write a multiple of "+BLOCK_SIZE+" bytes.");
@@ -723,6 +732,23 @@ exports.use = function (port, opts, callback) {
     }, _nested);
   }
   
+  // workaround for https://github.com/tessel/sdcard/issues/25
+  function writeBlocksSafe(i, data, callback, _nested) {
+    if (data.length % BLOCK_SIZE) throw Error("Must write a multiple of "+BLOCK_SIZE+" bytes.");
+    var n = (data.length / BLOCK_SIZE);
+    function callWriteBlock(j){
+      writeBlock(i+j, data.slice(j*BLOCK_SIZE, (j+1)*BLOCK_SIZE), function(err){
+        if (err) {
+          callback(err);
+        } else if (++j < n) {
+          callWriteBlock(j);
+        } else {
+          callback(null);
+        }
+      });
+    }
+    callWriteBlock(0);
+  }
   
   function modifyBlock(i,fn,callback) {
     callback = SPI_TRANSACTION_WRAPPER(callback, function () {

--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ exports.use = function (port, opts, callback) {
     getFilesystems: false,
     waitForCard: true,
     watchCard: false,
-    safeWrites: false
+    singleWrites: false
   }, opts);
   
   var card = new events.EventEmitter(),
@@ -687,10 +687,10 @@ exports.use = function (port, opts, callback) {
   }, _nested); }
   
   function writeBlocks(i, data, callback, _nested){
-    if (!opts.safeWrites) {
+    if (!opts.singleWrites) {
        writeBlocksMulti(i, data, callback, _nested);
     } else {
-       writeBlocksSafe(i, data, callback, _nested);
+       writeBlocksSingle(i, data, callback, _nested);
     }
   };
 
@@ -733,7 +733,7 @@ exports.use = function (port, opts, callback) {
   }
   
   // workaround for https://github.com/tessel/sdcard/issues/25
-  function writeBlocksSafe(i, data, callback, _nested) {
+  function writeBlocksSingle(i, data, callback, _nested) {
     if (data.length % BLOCK_SIZE) throw Error("Must write a multiple of "+BLOCK_SIZE+" bytes.");
     var n = (data.length / BLOCK_SIZE);
     function callWriteBlock(j){


### PR DESCRIPTION
using WRITE_MILTIPLE_BLOCK fails with one of my sd cards, i made this workaround to use multiple calls of WRITE_BLOCK instead. default behaviour is not changed. this adresses #25 